### PR TITLE
Change default values for inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         time-zone: Australia/Sydney
         version-file: test/dotnet/example/example.csproj
-        version-stub: '0.0.0.0'      
+        version-stub: '0.0.0.0'
+        leading-zeros: false
     - name: Test if version '${{ env.VERSION }}' is correctly set for .NET project
       run: cd test/dotnet/example && dotnet test
 
@@ -40,6 +41,7 @@ jobs:
         time-zone: Australia/Sydney
         version-file: test/dotnet/attribute/properties/AssemblyInfo.cs
         version-stub: '0.0.0.0'      
+        leading-zeros: false
     - name: Test if version '${{ env.VERSION }}' is correctly set for .NET project via AssemblyInfo.cs
       run: cd test/dotnet/attribute && dotnet test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
       with:
         time-zone: Australia/Sydney
         version-file: test/dotnet/example/example.csproj
-        version-stub: '0.0.0.0'
-        leading-zeros: false
     - name: Test if version '${{ env.VERSION }}' is correctly set for .NET project
       run: cd test/dotnet/example && dotnet test
 
@@ -40,8 +38,6 @@ jobs:
       with:
         time-zone: Australia/Sydney
         version-file: test/dotnet/attribute/properties/AssemblyInfo.cs
-        version-stub: '0.0.0.0'      
-        leading-zeros: false
     - name: Test if version '${{ env.VERSION }}' is correctly set for .NET project via AssemblyInfo.cs
       run: cd test/dotnet/attribute && dotnet test
 
@@ -60,7 +56,6 @@ jobs:
       uses: './'
       with:
         version-file: test/cabal/example/example.cabal
-        leading-zeros: false    
     - name: Test if version '${{ env.VERSION }}' is correctly set for Cabal project
       run: cd test/cabal/example && cabal update && cabal test
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         VERSION=$(date $([[ ${{ inputs.leading-zeros }} = true ]] && echo '+%Y.%m.%d' || echo '+%Y.%-m.%-d')).${{ github.run_number }}
         echo "Set project version to '$VERSION'"
         sed -i "s/${{ inputs.version-stub }}/$VERSION/" ${{ inputs.version-file }}
-        echo "::set-output name=project-version::$VERSION"
+        echo "project-version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "::group::Modified ${{ inputs.version-file }}"
         cat ${{ inputs.version-file }}

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
   version-stub:
     description: 'Version hardcoded in project file and replaced with resulting one'
     required: false
-    default: '0.0.0'
+    default: '0.0.0.0'
   leading-zeros:
     description: 'Pad month and day with 0: 06 vs 6'
     required: false
-    default: true
+    default: false
   time-zone:
     description: Time zone to be used to determine the current date/time
     required: false

--- a/test/cabal/example/example.cabal
+++ b/test/cabal/example/example.cabal
@@ -1,5 +1,5 @@
 Name:               example
-Version:            0.0.0
+Version:            0.0.0.0
 Build-type:         Simple
 Cabal-version:      >=1.10
 

--- a/test/dotnet/attribute/attribute.csproj
+++ b/test/dotnet/attribute/attribute.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 </Project>

--- a/test/dotnet/example/example.csproj
+++ b/test/dotnet/example/example.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
     <Version>0.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
 
   </ItemGroup>
 

--- a/test/node/example/package.json
+++ b/test/node/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.0.0",
+  "version": "0.0.0.0",
   "description": "",
   "main": "test.js",
   "scripts": {


### PR DESCRIPTION
- `version-stub`: by default is now `0.0.0.0`
- `leading-zeros`: by default is now `false`

Also fix `The `set-output` command is deprecated` warning