### PR TITLE
Handle missing `version-file` scenario 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,3 +80,20 @@ jobs:
         time-zone: ${{ matrix.time-zone }}
     - name: Test if version '${{ env.VERSION }}' is correctly set for Node project
       run: cd test/node/example && npm install && npm test
+
+  only-version-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set env.VERSION
+      id: set-version
+      uses: './'
+    - name: Check if env.VERSION is correctly set
+      run: |
+        if [[ -z "${{ env.VERSION }}" ]]; then
+          exit 1
+        elif [[ -z "${{ steps.set-version.outputs.project-version }}" ]]; then
+          exit 2
+        elif [[ "${{ env.VERSION }}" != "${{ steps.set-version.outputs.project-version }}" ]]; then
+          exit 3
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       TZ: Australia/Sydney
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set project version for Node project
       uses: './'
       with:
@@ -20,7 +20,7 @@ jobs:
   dotnet-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set project version for .NET project
       uses: './'
       with:
@@ -32,7 +32,7 @@ jobs:
   dotnet-cs-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set project version for .NET project via AssemblyInfo.cs
       uses: './'
       with:
@@ -48,7 +48,7 @@ jobs:
       matrix:
         date: ['current', '2021-06-07']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set current date to ${{ matrix.date }}
       if: ${{ matrix.date != 'current' }}
       run: sudo date -s ${{ matrix.date }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     env: ${{ matrix.env }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set project version for Node project
       uses: './'
       with:
@@ -99,3 +99,31 @@ jobs:
         elif [[ "${{ env.VERSION }}" != "${{ steps.set-version.outputs.project-version }}" ]]; then
           exit 3
         fi
+
+  publish-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - node-test
+      - dotnet-test
+      - dotnet-cs-test
+      - cabal-test
+      - time-zone-test
+      - only-version-test
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_BODY_FILE: ${{ github.workspace }}/release-description.md
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release notes
+        run: |
+          echo "RELEASE=$(git show -q --format=format:%s)" >> $GITHUB_ENV
+          git show -q --format=format:%b > ${{ env.RELEASE_BODY_FILE }}
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          commit: ${{ github.sha }}
+          name: ${{ env.RELEASE }}
+          bodyFile: ${{ env.RELEASE_BODY_FILE }}
+          makeLatest: ${{ github.ref == 'refs/heads/main' }}
+          prerelease: ${{ github.ref != 'refs/heads/main' }}
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,8 @@ jobs:
     - name: Set env.VERSION
       id: set-version
       uses: './'
+      with:
+        version-file-exists: false
     - name: Check if env.VERSION is correctly set
       run: |
         if [[ -z "${{ env.VERSION }}" ]]; then

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This format of versioning is better suited for projects with continious delivery
   Defaults to `false` e.g `2021/06/07` current date by default results in `2021.6.7.123` version and otherwise in `2021.06.07.123`
 - `time-zone`: (optional) time zone to be used to determine the current date/time  
   If not set the action runner current date/time is used 
-
+- `version-file-exists`: (optional) Check if specified by `version-file` parameter file does exist in repository
+  Defaults to: `true`. Set it to `false` if there is no `version-file` to set version in
+  e.g. when only `VERSION` environment variable is needed for build
 
 ## Output parameters
 
@@ -40,14 +42,14 @@ Add `EduardSergeev/project-version-action@v1` to your CI script after `actions/c
 
 ```yml
     - name: Set project version for Node project
-      uses: EduardSergeev/project-version-action@main
+      uses: EduardSergeev/project-version-action@v6
 ```
 
 If a different from `package.json` file is used or a different from `0.0.0.0` stub version value was specified set `project-file` and `version-stub` input parameters accordingly. For example for .NET project it could be:
 
 ```yml
     - name: Set project version for .NET project
-      uses: EduardSergeev/project-version-action@main
+      uses: EduardSergeev/project-version-action@v6
       with:
         version-file: example.csproj
         version-stub: '65534.65534.65534.65534'
@@ -57,7 +59,7 @@ By default this action does not pad single-digit "month" and "day" bits of the r
 
 ```yml
     - name: Set project version for Cabal project
-      uses: EduardSergeev/project-version-action@main
+      uses: EduardSergeev/project-version-action@v6
       with:
         version-file: example.cabal
         leading-zeros: true
@@ -77,9 +79,18 @@ or set input parameter `time-zone` to your local time zone, e.g.:
 
 ```yml
     - name: Set project version for Node project
-      uses: EduardSergeev/project-version-action@main
+      uses: EduardSergeev/project-version-action@v6
       with:
         time-zone: Australia/Sydney
 ```
 
 The former will change time zone for entire action job while the latter will use it only to calculate the version without changing it for the runner.
+
+If only `VERSION` environment variable (or `project-version` step's output parameter) is needed for a build and there is no `version-file` to set version in set `version-file-exists` input parameter to `false`, e.g.:
+
+```yml
+    - name: Set VERSION environment variable only
+      uses: EduardSergeev/project-version-action@v6
+      with:
+        version-file-exists: false
+```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   time-zone:
     description: Time zone to be used to determine the current date/time
     required: false
+  version-file-exists:
+    description: Fail if specified version-file does not exist
+    required: false
+    default: true
 
 outputs:
   project-version:
@@ -31,11 +35,18 @@ runs:
       run: |
         [[ ${{ inputs.time-zone != '' }} ]] && export TZ=${{ inputs.time-zone }}
         VERSION=$(date $([[ ${{ inputs.leading-zeros }} = true ]] && echo '+%Y.%m.%d' || echo '+%Y.%-m.%-d')).${{ github.run_number }}
-        echo "Set project version to '$VERSION'"
-        sed -i "s/${{ inputs.version-stub }}/$VERSION/" ${{ inputs.version-file }}
+        if [ "${{ inputs.version-file-exists }}" = true ]; then
+          if test -f "${{ inputs.version-file }}"; then
+            echo "Set project version to '$VERSION'" && \
+            sed -i "s/${{ inputs.version-stub }}/$VERSION/" ${{ inputs.version-file }} && \
+            echo "::group::Modified ${{ inputs.version-file }}" && \
+            cat ${{ inputs.version-file }} && \
+            echo "::endgroup::"
+          else
+            echo "::error file=${{ inputs.version-file-exists }},line=1::${{ inputs.version-file-required }} could not be found but is required" && \
+            exit 1
+          fi
+        fi
         echo "project-version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "::group::Modified ${{ inputs.version-file }}"
-        cat ${{ inputs.version-file }}
-        echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
- Add new (optional, default is `true`) input parameter `version-file-exists`:
  Then `version-file-exists: true` specified by `version-file` file must indeed exist in repository. Otherwise the action fails with `[version-file] could not be found but is required` error
- When `version-file-exists: false` and there is no `version-file` in repository the action now only sets `VERSION` environment variable and `project-version` action output to calculated project version