### PR TITLE
New badges in `README`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,6 @@ jobs:
           commit: ${{ github.sha }}
           name: ${{ env.RELEASE }}
           bodyFile: ${{ env.RELEASE_BODY_FILE }}
-          makeLatest: ${{ github.ref == 'refs/heads/main' }}
-          prerelease: ${{ github.ref != 'refs/heads/main' }}
+          makeLatest: ${{ startsWith(github.event.base_ref, 'refs/heads/main') }}
+          prerelease: ${{ !startsWith(github.event.base_ref, 'refs/heads/main') }}
   

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Project version action
+[![Build Status](https://github.com/EduardSergeev/project-version-action/workflows/build/badge.svg)](https://github.com/EduardSergeev/project-version-action/actions?query=workflow%3Abuild+branch%3Amain)
+[![Latest release](https://img.shields.io/github/v/release/EduardSergeev/project-version-action?label=release)](https://github.com/marketplace/actions/set-project-version)
+
 
 Sets project version to `YYYY.MM.DD.BUILD` where:
 - `YYYY.MM.DD` is the current action runner date


### PR DESCRIPTION
- Fix release creation
- Add new badges with links:
  - `build`: CI status of `main` branch
  - `release`: latest released version