### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This format of versioning is better suited for projects with continious delivery
 
 ## Usage
 
-In your project set version to some predefined stub version value. This value should probably still be a valid version number if you intend to compile your project outside Github action. For example in Node project `package.json` by default is expected to contain stub version `0.0.0`:
+### Default settings
+
+In your project set version to some predefined stub version value. This value should probably still be a valid version number if you intend to compile your project outside Github action. For example if Node project if its `package.json` contains stub version of `0.0.0.0` everything should work with default settings:
 ```json
 {
   "name": "example",
@@ -41,14 +43,30 @@ In your project set version to some predefined stub version value. This value sh
 }
 ```
 
-Add `EduardSergeev/project-version-action@v1` to your CI script after `actions/checkout@v2` step:
+### Placement in CI pipeline
+
+Add `EduardSergeev/project-version-action@v6` to your CI script after `actions/checkout@v3` step:
 
 ```yml
-    - name: Set project version for Node project
+    - uses: actions/checkout@v3
+    - name: Set project version for Node.js project
       uses: EduardSergeev/project-version-action@v6
 ```
 
-If a different from `package.json` file is used or a different from `0.0.0.0` stub version value was specified set `project-file` and `version-stub` input parameters accordingly. For example for .NET project it could be:
+All subsequent build steps then will be able to reference current build version ither via `VERSION` environment variable or via `project-version` step's output.
+
+### Input parameters
+
+If a different from `package.json` file is used or a different from `0.0.0.0` stub version value was specified set `project-file` and `version-stub` input parameters accordingly. For example for Node.js project with default three-parts `version` format it could be:
+
+```yml
+    - name: Set project version for Node.js project
+      uses: EduardSergeev/project-version-action@v6
+      with:
+        version-stub: '0.0.0'
+```
+
+While for .NET project with default "local" build number set to `65534.65534.65534.65534` it could be:
 
 ```yml
     - name: Set project version for .NET project
@@ -97,3 +115,7 @@ If only `VERSION` environment variable (or `project-version` step's output param
       with:
         version-file-exists: false
 ```
+
+### Output parameter
+
+In addition to environment variable `VERSION` being set to the calculated current build number (which can be used in the subsequent build steps via `${{ env.VERSION }}` expression) this action alse sets output parameter `project-version` to the same build number which can read in the consequent build steps via `${{ steps.[this-action-step_id].outputs.project-version }}` expression.


### PR DESCRIPTION
- Fix: documentation:
  - Fix: default `version` value used in text:
    It is now `0.0.0.0`, not three-parts but four
  - Add: example of three-part version configuration for Node.js project
  - Add: `Output parameter` section